### PR TITLE
Add GitHub rate limit checks and exponential backoff

### DIFF
--- a/shared/__init__.py
+++ b/shared/__init__.py
@@ -41,6 +41,7 @@ import subprocess
 from getpass import getpass
 from glob import glob
 from textwrap import dedent, indent
+from time import sleep
 from typing import Any, Dict, List
 
 from github import Github, enable_console_debug_logging
@@ -432,3 +433,24 @@ def get_index_info(clones: List[str]) -> Dict[str, List[str]]:
             index_info["clean"].append(clone)
 
     return index_info
+
+
+def github_rate_limit_wait(config: Dict[str, Any]) -> None:
+    """Waits for the GitHub API to accept requests."""
+
+    g = Github(config["github_token"])
+
+    attempt = 1
+    rate_limit = g.get_rate_limit().rate
+    while rate_limit.remaining == 0:
+        sleep_time = attempt**2
+        cprint(
+            f"WARNING: Rate limited. Waiting {sleep_time} seconds before continuing.",
+            colors.WARNING,
+            2,
+        )
+        sleep(sleep_time)
+        attempt += 1
+        rate_limit = g.get_rate_limit().rate
+
+    return

--- a/shared/sync.py
+++ b/shared/sync.py
@@ -21,10 +21,17 @@ import sys
 from multiprocessing.pool import ThreadPool
 from typing import Any, Dict, Generator, List
 
-from github import Github
-from github.GithubException import GithubException
+from github import Github, GithubException
 
-from . import REPODIR, colors, cprint, get_clones, get_default_branch, get_org_repos
+from . import (
+    REPODIR,
+    colors,
+    cprint,
+    get_clones,
+    get_default_branch,
+    get_org_repos,
+    github_rate_limit_wait,
+)
 
 
 def get_user_forks(org_repos: List[Any], config: Dict[str, Any]) -> List[Any]:
@@ -74,6 +81,7 @@ def create_user_forks(
     for idx, repo in enumerate(repos_to_fork):
         print(f"Forking repo {repo.full_name} ({idx + 1} of {len(repos_to_fork)})...")
         try:
+            github_rate_limit_wait(config)
             yield repo.create_fork()
         except GithubException as err:
             cprint(


### PR DESCRIPTION
This PR implements a function to check the GitHub /rate_limit endpoint for details. If there are no remaining tasks, the function performs an exponential backup until it becomes available again.

The function is implemented into `sync` and `pr` before interacting with the GitHub API.

This fixes #13.

> [!NOTE]  
> I was not able to validate that this works as expected. While testing, I continuously ran into issues running `sync`. The code fails before reaching my changes at the `Syncing clone repos/XXXXXXXX (# of ##)...` step. Setting the number of thread workers to 1 did not help.