### PR TITLE
Add GitHub Actions release automation

### DIFF
--- a/.github/workflows/release-prep.yml
+++ b/.github/workflows/release-prep.yml
@@ -1,0 +1,48 @@
+name: Release prep
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Version to release (e.g. 1.3.0)"
+        required: true
+        type: string
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  prep:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: dev
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Bump version and promote changelog
+        env:
+          VERSION: ${{ inputs.version }}
+        run: python .github/workflows/release_tools.py prep "$VERSION"
+
+      - name: Open release PR
+        uses: peter-evans/create-pull-request@v7
+        with:
+          branch: release/v${{ inputs.version }}
+          base: dev
+          title: "Release v${{ inputs.version }}"
+          body: |
+            Prepares the v${{ inputs.version }} release.
+
+            - Bumps `shared/__init__.py` to `${{ inputs.version }}`
+            - Promotes the `[Unreleased]` changelog section to `[${{ inputs.version }}]`
+            - Updates the compare links at the bottom of `CHANGELOG.md`
+
+            After this PR is merged into `dev` and then into `main`, tag `main` with
+            `v${{ inputs.version }}` and push the tag to trigger the release workflow.
+          commit-message: "Prepare release v${{ inputs.version }}"
+          delete-branch: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,7 +3,7 @@ name: Release
 on:
   push:
     tags:
-      - "v[0-9]+.[0-9]+.[0-9]+"
+      - "v[0-9]*.[0-9]*.[0-9]*"
 
 permissions:
   contents: write

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,42 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - "v[0-9]+.[0-9]+.[0-9]+"
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+          cache: pip
+          cache-dependency-path: requirements.txt
+
+      - name: Install dependencies
+        run: pip install -r requirements.txt
+
+      - name: Validate version consistency
+        run: python .github/workflows/release_tools.py check "${GITHUB_REF_NAME}"
+
+      - name: Run unit tests
+        run: python -m unittest discover -v tests
+
+      - name: Extract release notes
+        run: python .github/workflows/release_tools.py notes "${GITHUB_REF_NAME}" > RELEASE_NOTES.md
+
+      - name: Publish GitHub release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ github.ref_name }}
+          name: ${{ github.ref_name }}
+          body_path: RELEASE_NOTES.md
+          draft: false
+          prerelease: false

--- a/.github/workflows/release_tools.py
+++ b/.github/workflows/release_tools.py
@@ -1,0 +1,171 @@
+"""Helpers used by release.yml and release-prep.yml.
+
+Subcommands:
+    check <tag>      Fail unless tag, __version__, and CHANGELOG.md agree.
+    notes <tag>      Print the CHANGELOG section body for <tag> to stdout.
+    prep  <version>  Rewrite shared/__init__.py and CHANGELOG.md for a new release.
+"""
+
+from __future__ import annotations
+
+import datetime
+import pathlib
+import re
+import sys
+
+ROOT = pathlib.Path(__file__).resolve().parents[2]
+VERSION_FILE = ROOT / "shared" / "__init__.py"
+CHANGELOG = ROOT / "CHANGELOG.md"
+COMPARE_URL = "https://github.com/homebysix/repo-lasso/compare"
+
+VERSION_RE = re.compile(r'^__version__\s*=\s*"([^"]+)"', re.MULTILINE)
+SEMVER_RE = re.compile(r"^\d+\.\d+\.\d+$")
+# Matches both "## [1.2.0] - 2024-06-23" and the legacy "## 1.0.0 - 2021-03-29".
+RELEASED_SECTION_RE = re.compile(r"^## \[?(\d+\.\d+\.\d+)\]? - \d{4}-\d{2}-\d{2}")
+
+
+def read_version() -> str:
+    match = VERSION_RE.search(VERSION_FILE.read_text())
+    if not match:
+        sys.exit(f"Could not find __version__ in {VERSION_FILE}")
+    return match.group(1)
+
+
+def strip_v(tag: str) -> str:
+    return tag[1:] if tag.startswith("v") else tag
+
+
+def split_changelog(text: str) -> tuple[str, list[tuple[str, str]], str]:
+    """Return (header, [(section_header, section_body), ...], footer).
+
+    ``footer`` is the trailing block of ``[x.y.z]: ...`` compare links.
+    """
+    lines = text.splitlines()
+    footer_start = next(
+        (i for i, line in enumerate(lines) if re.match(r"^\[[^\]]+\]:\s*http", line)),
+        len(lines),
+    )
+    body = "\n".join(lines[:footer_start])
+    footer = "\n".join(lines[footer_start:])
+
+    sections: list[tuple[str, str]] = []
+    current_header: str | None = None
+    current_body: list[str] = []
+    preface: list[str] = []
+    for line in body.splitlines():
+        if line.startswith("## "):
+            if current_header is None:
+                preface = current_body[:]
+            else:
+                sections.append((current_header, "\n".join(current_body).strip("\n")))
+            current_header = line
+            current_body = []
+        else:
+            current_body.append(line)
+    if current_header is not None:
+        sections.append((current_header, "\n".join(current_body).strip("\n")))
+
+    return "\n".join(preface).rstrip() + "\n", sections, footer
+
+
+def find_section_body(sections: list[tuple[str, str]], version: str) -> str | None:
+    for header, body in sections:
+        match = RELEASED_SECTION_RE.match(header)
+        if match and match.group(1) == version:
+            return body.strip()
+    return None
+
+
+def check(tag: str) -> None:
+    if not tag.startswith("v") or not SEMVER_RE.match(strip_v(tag)):
+        sys.exit(f"Tag {tag!r} must match vX.Y.Z")
+    version = strip_v(tag)
+
+    declared = read_version()
+    if declared != version:
+        sys.exit(
+            f"Tag {tag} does not match __version__={declared!r} in {VERSION_FILE.name}"
+        )
+
+    _, sections, footer = split_changelog(CHANGELOG.read_text())
+    if find_section_body(sections, version) is None:
+        sys.exit(f"CHANGELOG.md has no section for {version}")
+    if not any(line.startswith(f"[{version}]:") for line in footer.splitlines()):
+        sys.exit(f"CHANGELOG.md footer is missing a compare link for [{version}]")
+
+    print(f"OK: {tag} matches __version__ and CHANGELOG.md")
+
+
+def notes(tag: str) -> None:
+    version = strip_v(tag)
+    _, sections, _ = split_changelog(CHANGELOG.read_text())
+    body = find_section_body(sections, version)
+    if body is None:
+        sys.exit(f"CHANGELOG.md has no section for {version}")
+    print(body)
+
+
+def prep(version: str) -> None:
+    if not SEMVER_RE.match(version):
+        sys.exit(f"Version {version!r} must be X.Y.Z")
+
+    VERSION_FILE.write_text(
+        VERSION_RE.sub(f'__version__ = "{version}"', VERSION_FILE.read_text(), count=1)
+    )
+
+    text = CHANGELOG.read_text()
+    header, sections, footer = split_changelog(text)
+    if not sections or not sections[0][0].startswith("## [Unreleased]"):
+        sys.exit("CHANGELOG.md must start with a '## [Unreleased]' section")
+
+    unreleased_body = sections[0][1].strip()
+    if not unreleased_body or unreleased_body.lower().startswith("nothing yet"):
+        sys.exit("CHANGELOG.md [Unreleased] section is empty — nothing to release")
+
+    today = datetime.date.today().isoformat()
+    new_sections = [
+        ("## [Unreleased]", "Nothing yet."),
+        (f"## [{version}] - {today}", unreleased_body),
+        *sections[1:],
+    ]
+
+    prior_version = next(
+        (m.group(1) for h, _ in sections[1:] if (m := RELEASED_SECTION_RE.match(h))),
+        None,
+    )
+    if prior_version is None:
+        sys.exit("Could not find a prior released version in CHANGELOG.md")
+
+    footer_lines = footer.splitlines() if footer else []
+    kept = [line for line in footer_lines if not line.startswith("[Unreleased]:")]
+    new_footer_lines = [
+        f"[Unreleased]: {COMPARE_URL}/v{version}...HEAD",
+        f"[{version}]: {COMPARE_URL}/v{prior_version}...v{version}",
+        *kept,
+    ]
+
+    parts = [header.rstrip()]
+    for section_header, section_body in new_sections:
+        parts += ["", section_header, "", section_body.strip()]
+    parts += [""] + new_footer_lines
+    CHANGELOG.write_text("\n".join(parts) + "\n")
+
+    print(f"Prepared release v{version} (previous: v{prior_version})")
+
+
+def main() -> None:
+    if len(sys.argv) != 3:
+        sys.exit(__doc__)
+    cmd, arg = sys.argv[1], sys.argv[2]
+    if cmd == "check":
+        check(arg)
+    elif cmd == "notes":
+        notes(arg)
+    elif cmd == "prep":
+        prep(arg)
+    else:
+        sys.exit(__doc__)
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/workflows/release_tools.py
+++ b/.github/workflows/release_tools.py
@@ -129,15 +129,18 @@ def prep(version: str) -> None:
         *sections[1:],
     ]
 
-    prior_version = next(
-        (m.group(1) for h, _ in sections[1:] if (m := RELEASED_SECTION_RE.match(h))),
-        None,
-    )
+    prior_version = None
+    for header_line, _ in sections[1:]:
+        match = RELEASED_SECTION_RE.match(header_line)
+        if match:
+            prior_version = match.group(1)
+            break
     if prior_version is None:
         sys.exit("Could not find a prior released version in CHANGELOG.md")
 
     footer_lines = footer.splitlines() if footer else []
-    kept = [line for line in footer_lines if not line.startswith("[Unreleased]:")]
+    drop_prefixes = ("[Unreleased]:", f"[{version}]:")
+    kept = [line for line in footer_lines if not line.startswith(drop_prefixes)]
     new_footer_lines = [
         f"[Unreleased]: {COMPARE_URL}/v{version}...HEAD",
         f"[{version}]: {COMPARE_URL}/v{prior_version}...v{version}",

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,0 +1,77 @@
+# Releasing Repo Lasso
+
+Releases are automated via two GitHub Actions workflows in `.github/workflows/`:
+
+- **`release-prep.yml`** — opens a PR that bumps the version and promotes the
+  `[Unreleased]` changelog section.
+- **`release.yml`** — runs tests and publishes the GitHub release when a
+  `vX.Y.Z` tag is pushed.
+
+The shared helper `release_tools.py` implements the version/changelog logic
+used by both workflows.
+
+## Cutting a release
+
+1. **Make sure `[Unreleased]` is up to date.** Every PR merged into `dev`
+   since the last release should be reflected there. The prep workflow
+   refuses to run if the section is empty or says "Nothing yet."
+
+2. **Run the prep workflow.**
+
+   - Go to **Actions → Release prep → Run workflow**.
+   - Enter the target version (e.g. `1.3.0`). Do not include the `v` prefix.
+   - The workflow opens a `release/vX.Y.Z` PR against `dev` that bumps
+     `shared/__init__.py` and rewrites `CHANGELOG.md`.
+
+3. **Review and merge the prep PR into `dev`.** Then merge `dev` into `main`
+   the normal way (PR from `dev` → `main`).
+
+4. **Tag `main` and push the tag.**
+
+   ```sh
+   git checkout main
+   git pull
+   git tag vX.Y.Z
+   git push origin vX.Y.Z
+   ```
+
+5. **Watch the release workflow.** Pushing the tag triggers `release.yml`,
+   which:
+
+   - Verifies the tag matches `__version__` and that `CHANGELOG.md` has a
+     matching `## [X.Y.Z] - YYYY-MM-DD` section and footer compare link.
+   - Runs `python -m unittest discover tests`.
+   - Extracts the changelog section for `X.Y.Z` and publishes it as the
+     GitHub release body.
+
+   If any step fails, no release is published — fix the issue and re-tag.
+
+## Cutting a release by hand
+
+If the prep workflow is unavailable, the same result can be produced locally:
+
+```sh
+python .github/workflows/release_tools.py prep 1.3.0
+```
+
+…then open a PR with the resulting changes.
+
+## Re-running a failed release
+
+If `release.yml` fails after publishing is already partially complete,
+delete the tag (locally and on the remote) and any draft release, fix the
+underlying issue, and re-push the tag:
+
+```sh
+git tag -d vX.Y.Z
+git push origin :refs/tags/vX.Y.Z
+```
+
+## What is **not** automated
+
+- Tag creation. Tagging `main` is still a deliberate human step.
+- Package publication. Repo Lasso is not distributed via PyPI; users install
+  by cloning the repo, so no artifacts beyond GitHub's auto-generated source
+  tarballs are published.
+- Tag signing. Historical tags are lightweight; keep doing that unless the
+  project decides to sign going forward.


### PR DESCRIPTION
## Summary

Automates future Repo Lasso releases end-to-end via GitHub Actions, replacing the manual "bump version, edit CHANGELOG, copy-paste into the GitHub release UI" dance.

- **`.github/workflows/release.yml`** — on `vX.Y.Z` tag push, validates that the tag matches `shared.__version__` and that `CHANGELOG.md` has a matching `## [X.Y.Z] - YYYY-MM-DD` section and compare-link footer, runs the unit tests, then publishes a GitHub release with the changelog section as the body.
- **`.github/workflows/release-prep.yml`** — `workflow_dispatch` input `version=X.Y.Z`; bumps `shared/__init__.py`, promotes `[Unreleased]` to a dated section, rewrites the compare links, and opens a PR against `dev`.
- **`.github/workflows/release_tools.py`** — shared Python helper with `check` / `notes` / `prep` subcommands used by both workflows.
- **`RELEASING.md`** — step-by-step instructions for cutting a release with these workflows, plus a "by hand" fallback and rollback notes.

## What's intentionally not automated

- Tag creation — still a deliberate human `git tag && git push`.
- PyPI publishing — Repo Lasso isn't on PyPI; install remains `git clone`.
- Tag signing — historical tags are lightweight; no change.

## Test plan

- [ ] Run the **Release prep** workflow with `version=1.3.0`; confirm it opens a PR that bumps `shared/__init__.py` to `1.3.0`, promotes `[Unreleased]` → `## [1.3.0] - <today>`, and rewrites the footer compare links correctly.
- [ ] Merge the prep PR into `dev`, then merge `dev` → `main`, then push tag `v1.3.0`; confirm the **Release** workflow runs unit tests and publishes a GitHub release whose body matches the `## [1.3.0]` changelog section.
- [ ] Push a deliberately mismatched tag (e.g. `v9.9.9`) on a scratch branch; confirm the workflow fails at the "Validate version consistency" step before publishing.
- [ ] Run release-prep when `[Unreleased]` is empty/"Nothing yet."; confirm the prep step refuses with a clear error.
- [ ] (Sanity) Locally: `python .github/workflows/release_tools.py notes v1.2.0` output matches the existing v1.2.0 GitHub release body.